### PR TITLE
Fix for empty error array being created on all responses

### DIFF
--- a/src/EntityGraphQL/Compiler/GraphQLResultNode.cs
+++ b/src/EntityGraphQL/Compiler/GraphQLResultNode.cs
@@ -84,7 +84,7 @@ namespace EntityGraphQL.Compiler
             }
 
             if (validator.Errors.Count > 0)
-                result.Errors.AddRange(validator.Errors);
+                result.AddErrors(validator.Errors);
 
             return result;
         }

--- a/src/EntityGraphQL/QueryResult.cs
+++ b/src/EntityGraphQL/QueryResult.cs
@@ -1,21 +1,47 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace EntityGraphQL
 {
     public class QueryResult
     {
+        private List<GraphQLError> errors = null;
         [JsonProperty("errors")]
-        public List<GraphQLError> Errors => (List<GraphQLError>)dataResults["errors"];
+        public ReadOnlyCollection<GraphQLError> Errors => errors?.AsReadOnly();
         [JsonProperty("data")]
-        public ConcurrentDictionary<string, object> Data => (ConcurrentDictionary<string, object>)dataResults["data"];
-        private readonly ConcurrentDictionary<string, object> dataResults = new ConcurrentDictionary<string, object>();
+        public readonly ConcurrentDictionary<string, object> Data = new ConcurrentDictionary<string, object>();
 
-        public QueryResult()
+        public QueryResult() { }
+        public QueryResult(GraphQLError error)
         {
-            dataResults["errors"] = new List<GraphQLError>();
-            dataResults["data"] = new ConcurrentDictionary<string, object>();
+            errors = new List<GraphQLError> { error };
+        }
+        public QueryResult(IEnumerable<GraphQLError> errors)
+        {
+            this.errors = errors.ToList();
+        }
+
+        public void AddError(GraphQLError error)
+        {
+            if (errors == null)
+            {
+                errors = new List<GraphQLError>();
+            }
+
+            errors.Add(error);
+        }
+
+        public void AddErrors(IEnumerable<GraphQLError> errors)
+        {
+            if (errors == null)
+            {
+                errors = new List<GraphQLError>();
+            }
+
+            this.errors.AddRange(errors);
         }
     }
 }

--- a/src/EntityGraphQL/Schema/SchemaProvider.cs
+++ b/src/EntityGraphQL/Schema/SchemaProvider.cs
@@ -124,7 +124,7 @@ namespace EntityGraphQL.Schema
             catch (Exception ex)
             {
                 // error with the whole query
-                result = new QueryResult { Errors = { new GraphQLError(ex.InnerException != null ? ex.InnerException.Message : ex.Message) } };
+                result = new QueryResult(new GraphQLError(ex.InnerException != null ? ex.InnerException.Message : ex.Message));
             }
 
             return result;


### PR DESCRIPTION
Fix the issue where an empty error array is sent with every response.

`errors` property should not be present on the response if there are no errors per the [graphQL specification](https://spec.graphql.org/June2018/#sec-Errors).